### PR TITLE
Upload function from a provided URL

### DIFF
--- a/src/scripts/upload_from_url.sh
+++ b/src/scripts/upload_from_url.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+# upload.sh url name threads subfolder_path base64_encoded
+
+curl http://localhost:8080/uploadFromUrl --data "{\"environment\": {\"ENVVAR\":\"value\" }, \"name\": \"$2\", \"threads\": $3, \"url\": \"$1\", \"subfolder_path\": \"$4\", \"base64_encoded\": $5}"


### PR DESCRIPTION
To ease the interaction with tinyFaas a user could simply provide a URL of a zip to deploy to a local tinyFaas. 

This is for example useful if one want's to deploy functions directly from Github. 
  